### PR TITLE
Update Docker Hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple **Speedtest exporter** for **Prometheus** written in **Python** using the
 [**CloudFlare** Python CLI from Tom Evslin](https://pypi.org/project/cloudflarepycli).
 Installed with `pip install cloudflarepycli`. Reports the 90 percentile speed in line with the cloudflare website.
 
-Published on [Docker Hub here](https://hub.docker.com/repository/docker/redorbluepill/cloudflare-speedtest-exporter).
+Published on [Docker Hub here](https://hub.docker.com/r/redorbluepill/cloudflare-speedtest-exporter).
 
 ## Thanks to
 


### PR DESCRIPTION
The previous link sends you to a Docker Hub login page, before redirecting to the link this is being updated to. Using this version of the link doesn't require a login, which is vastly more preferred.