### PR TITLE
Fix lint workflow step label

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout cout
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- update job step name in lint workflow to checkout code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f02cdbc14832ea53fc6e299530cc4